### PR TITLE
Move images to autopilotpattern repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Triton trusted Consul
+# Consul autopilot pattern
 
 [Consul](http://www.consul.io/) in Docker, designed for availability and durability.
 
-[![DockerPulls](https://img.shields.io/docker/pulls/misterbisson/triton-consul.svg)](https://registry.hub.docker.com/u/misterbisson/triton-consul/)
-[![DockerStars](https://img.shields.io/docker/stars/misterbisson/triton-consul.svg)](https://registry.hub.docker.com/u/misterbisson/triton-consul/)
+[![DockerPulls](https://img.shields.io/docker/pulls/autopilotpattern/consul.svg)](https://registry.hub.docker.com/u/autopilotpattern/consul/)
+[![DockerStars](https://img.shields.io/docker/stars/autopilotpattern/consul.svg)](https://registry.hub.docker.com/u/autopilotpattern/consul/)
 
 ## Prep your environment
 
@@ -18,7 +18,7 @@ curl -O https://raw.githubusercontent.com/joyent/sdc-docker/master/tools/sdc-doc
 
 ## Start a trusted Consul raft
 
-1. [Clone](https://github.com/misterbisson/triton-consul) or [download](https://github.com/misterbisson/triton-consul/archive/master.zip) this repo
+1. [Clone](https://github.com/autopilotpattern/consul) or [download](https://github.com/autopilotpattern/consul/archive/master.zip) this repo
 1. `cd` into the cloned or downloaded directory
 1. Execute `bash start.sh` to start everything up
 1. The Consul dashboard should automatically open in your browser, or follow the links output by the `start.sh` script

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@
 # environment variable is used once at bootstrap and then forever
 # discarded by that node.
 consul:
-    image: misterbisson/triton-consul:latest
+    image: autopilotpattern/consul:latest
     restart: always
     mem_limit: 128m
     ports:

--- a/makefile
+++ b/makefile
@@ -7,9 +7,8 @@ TAG?=latest
 
 # run the Docker build
 build:
-	docker build -t="misterbisson/triton-consul:${TAG}" .
+	docker build -t="autopilotpattern/consul:${TAG}" .
 
 # push our image to the public registry
 ship: build
-	docker push "misterbisson/triton-consul:${TAG}"
-
+	docker push "autopilotpattern/consul:${TAG}"


### PR DESCRIPTION
@misterbisson this updates the repo to have container images moved under the autopilotpattern org.

The new images have been pushed to:
https://hub.docker.com/r/autopilotpattern/consul/
