### PR TITLE
removed loopback address DNS entry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,6 @@ consul:
     mem_limit: 128m
     ports:
         - 8500
-    dns:
-       - 127.0.0.1
     env_file:
       - _env
     command: >


### PR DESCRIPTION
There appears to be little use for this. In the Triton Cloud, instances are able to resolve the $CONSUL address with or without this parameter. In Triton Private Cloud implementations, setting to 127.0.0.1 fails and simply leaving the resolvers to be set by the network configuration, seems much better in my opinion.