### PR TITLE
added preStop for consul leave

### DIFF
--- a/etc/containerpilot.json
+++ b/etc/containerpilot.json
@@ -1,6 +1,7 @@
 {
   "consul": "127.0.0.1:8500",
   "preStart": ["/usr/local/bin/consul-manage", "preStart"],
+  "preStop": ["consul", "leave"],
   "services": [
     {
       "name": "consul",


### PR DESCRIPTION
Consul needs to leave the cluster in a graceful manner and without "consul leave", member states show up as failed.  These nodes are still considered members and causes issues with quorum.