### PR TITLE
Add CONSUL_DATACENTER_NAME env

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ services:
 
 In our experience, including a Consul cluster within a project's `docker-compose.yml` can help developers understand and test how a service should be discovered and registered within a wider infrastructure context.
 
+#### Environment Variables
+
+- `CONSUL_DATACENTER_NAME`: sets the name of the data center in which the Consul cluster is running.
+
 ### Clients
 
 ContainerPilot utilizes Consul's [HTTP Agent API](https://www.consul.io/api/agent.html) for a handful of endpoints, such as `UpdateTTL`, `CheckRegister`, `ServiceRegister` and `ServiceDeregister`. Connecting ContainerPilot to Consul can be achieved by running Consul as a client to a cluster (mentioned above). It's easy to run this Consul client agent from ContainerPilot itself.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,17 @@ In our experience, including a Consul cluster within a project's `docker-compose
 
 #### Environment Variables
 
-- `CONSUL_DATACENTER_NAME`: sets the name of the data center in which the Consul cluster is running.
+- `CONSUL_DEV`: Enable development mode, allowing a node to self-elect as a cluster leader. Consul flag: [`-dev`](https://www.consul.io/docs/agent/options.html#_dev).
+    - The following errors will occur if `CONSUL_DEV` is omitted and not enough Consul instances are deployed:
+    ```
+    [ERR] agent: failed to sync remote state: No cluster leader
+    [ERR] agent: failed to sync changes: No cluster leader
+    [ERR] agent: Coordinate update error: No cluster leader
+    ```
+- `CONSUL_DATACENTER_NAME`: Explicitly set the name of the data center in which Consul is running. Consul flag: [`-datacenter`](https://www.consul.io/docs/agent/options.html#datacenter).
+    - If this variable is specified it will be used as-is.
+    - If not specified, automatic detection of the datacenter will be attempted. See [issue #23](https://github.com/autopilotpattern/consul/issues/23) for more details.
+    - Consul's default of "dc1" will be used if none of the above apply.
 
 ### Clients
 

--- a/bin/consul-manage
+++ b/bin/consul-manage
@@ -9,8 +9,17 @@ preStart() {
     _log "Updating consul advertise address"
     sed -i "s/CONTAINERPILOT_CONSUL_IP/${CONTAINERPILOT_CONSUL_IP}/" /etc/consul/consul.hcl
 
-    _log "Updating consul datacenter name"
-    sed -i "s/CONSUL_DATACENTER_NAME/${CONSUL_DATACENTER_NAME:-dc1}/" /etc/consul/consul.hcl
+    if [ -n "$CONSUL_DATACENTER_NAME" ]; then
+        _log "Updating consul datacenter name (specified: '${CONSUL_DATACENTER_NAME}' )"
+        sed -i "s/CONSUL_DATACENTER_NAME/${CONSUL_DATACENTER_NAME}/" /etc/consul/consul.hcl
+    elif [ -f "/native/usr/sbin/mdata-get" ]; then
+        DETECTED_DATACENTER_NAME=$(/native/usr/sbin/mdata-get sdc:datacenter_name)
+        _log "Updating consul datacenter name (detected: '${DETECTED_DATACENTER_NAME}')"
+        sed -i "s/CONSUL_DATACENTER_NAME/${DETECTED_DATACENTER_NAME}/" /etc/consul/consul.hcl
+    else
+        _log "Updating consul datacenter name (default: 'dc1')"
+        sed -i "s/CONSUL_DATACENTER_NAME/dc1/" /etc/consul/consul.hcl
+    fi
 }
 
 #

--- a/bin/consul-manage
+++ b/bin/consul-manage
@@ -8,6 +8,9 @@ set -eo pipefail
 preStart() {
     _log "Updating consul advertise address"
     sed -i "s/CONTAINERPILOT_CONSUL_IP/${CONTAINERPILOT_CONSUL_IP}/" /etc/consul/consul.hcl
+
+    _log "Updating consul datacenter name"
+    sed -i "s/CONSUL_DATACENTER_NAME/${CONSUL_DATACENTER_NAME:-dc1}/" /etc/consul/consul.hcl
 }
 
 #

--- a/etc/consul.hcl
+++ b/etc/consul.hcl
@@ -1,4 +1,5 @@
 bind_addr = "CONTAINERPILOT_CONSUL_IP"
+datacenter = "CONSUL_DATACENTER_NAME"
 data_dir = "/data"
 client_addr = "0.0.0.0"
 ports {

--- a/local-compose.yml
+++ b/local-compose.yml
@@ -15,5 +15,6 @@ services:
         - 8500
     environment:
       - CONSUL=consul
+      - CONSUL_DATACENTER_NAME=dc1
     command: >
       /usr/local/bin/containerpilot


### PR DESCRIPTION
Resolves #23

The environment variable in `local-compose.yml` is redudant with the bash default but calls out to users that it can be changed. Commenting it out is another option.

Feedback appreciated.